### PR TITLE
Refactor structure!

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default _apiData => Component => {
       Object.keys(_apiData).map(key => {
         this._data[key] = {};
         if (store.has(key)) {
-          this._data[key] = stpre.get(key);
+          this._data[key] = store.get(key);
           return;
         }
         get(_apiData[key]).then(result => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,36 +1,26 @@
-import React from 'react';
-import store from './store';
-import { get } from './fetch';
+import React from "react";
+import { get } from "./fetch";
+import store from "./store";
 
 export default _apiData => Component => {
   return class extends React.Component {
-    _data = {};
-
-    constructor() {
-      super();
-      Object.keys(_apiData).map(k => this._data[k] = {});
-    }
-
-    fetchData() {
-      Object.entries(_apiData).map(([k, url]) => {
-        if (typeof store[url] === 'undefined') {
-          return get(url).then(result => {
-            this._data[k] = store[url] = result;
-            this.forceUpdate();
-          });
+    componentWillMount() {
+      this._data = {};
+      Object.keys(_apiData).map(key => {
+        this._data[key] = {};
+        if (store.has(key)) {
+          this._data[key] = stpre.get(key);
+          return;
         }
-
-        this._data[k] = store[url];
-        this.forceUpdate();
-      })
+        get(_apiData[key]).then(result => {
+          store.set(key, result);
+          this._data[key] = result;
+          this.forceUpdate();
+        });
+      });
     }
-
-    componentDidMount() {
-      this.fetchData();
-    }
-
     render() {
-      return <Component {...this._data} />
+      return <Component {...this._data} />;
     }
-  }
-}
+  };
+};

--- a/src/store.js
+++ b/src/store.js
@@ -1,1 +1,3 @@
-export default {};
+const store = new Map();
+
+export default store;

--- a/src/vanilla.js
+++ b/src/vanilla.js
@@ -1,23 +1,22 @@
-import store from './store';
-import { get } from './fetch';
+import store from "./store";
+import { get } from "./fetch";
 
 export default _apiData => _target => {
-
-  Object.keys(_apiData).map(k => _target.prototype[k] = {});
-
-  Object.entries(_apiData).map(([k, url]) => {
-    if (typeof store[url] === 'undefined') {
-      return get(url).then(result => {
-        _target.prototype[k] = store[url] = result;
-        if (typeof _target.prototype.didRecieveData === 'function') {
-          _target.prototype.didRecieveData(store);
-        }
-      });
+  Object.keys(_apiData).map(key => {
+    _target.prototype[key] = {};
+    if (store.has(key)) {
+      _target.prototype[key] = store.get(key);
+      return;
     }
-
-    _target.prototype[k] = store[url];
-    if (typeof _target.prototype.didRecieveData === 'function') {
-      _target.prototype.didRecieveData(store);
-    }
-  })
-}
+    get(_apiData[key]).then(result => {
+      store.set(key, result);
+      _target.prototype[key] = result;
+      if (typeof _target.prototype.didRecieveData === "function") {
+        _target.prototype.didRecieveData();
+      }
+    });
+  });
+  if (typeof _target.prototype.didRecieveData === "function") {
+    _target.prototype.didRecieveData();
+  }
+};


### PR DESCRIPTION
This update contains major changes to the structure of both the normal and vanilla versions.

**Updates:**
- Switch the store from `object` to `Map` (faster with more functionality).
- Simplified with less functions (to make it smaller).
- Provides empty data values (so undefined values will never happen) like before.
- Doesn't pass `store` to vanilla class (because the prototype already has the values).
- Support for IE by switching `Object.entries()` for `Object.keys()`.

**Bytes:**
Normal: `957` -> `734`.
Vanilla: `503` -> `258`.